### PR TITLE
Removed mapControls

### DIFF
--- a/src/Components/CopperMap.js
+++ b/src/Components/CopperMap.js
@@ -10,6 +10,12 @@ const GameMap = withGoogleMap(props => (
         defaultZoom={18}
         defaultCenter={props.center}
         onClick={props.onMapClick}
+        options={{
+            mapTypeControl: false,
+            streetViewControl: false,
+            // zoomControl: false,
+        }}
+
     >
         <Circle
             center={props.center}


### PR DESCRIPTION
This PR removes all map controls except for zoom controls, good to have during development. Pan and Zoom still works thought. Also good to have during dev.