### PR TITLE
Feature/display name

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -4,7 +4,7 @@ import { pathToJS } from 'react-redux-firebase';
 import base from '../../Firebase/base';
 import LoginContainer from '../LoginContainer/LoginContainer';
 import GameContainer from '../GameContainer/GameContainer';
-import {getPricePerSquareMeter} from '../../Helpers/PointsHelpers';
+//import {getPricePerSquareMeter} from '../../Helpers/PointsHelpers';
 
 class App extends React.Component {
     constructor(){

--- a/src/Components/Navigation/Navigationbar.jsx
+++ b/src/Components/Navigation/Navigationbar.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { firebaseConnect } from 'react-redux-firebase';
+import { connect } from 'react-redux';
+import { firebaseConnect, pathToJS, dataToJS} from 'react-redux-firebase';
 import {Navbar, Nav, NavItem, NavDropdown, MenuItem} from 'react-bootstrap';
 
 const Navigationbar = (props) => {
@@ -19,7 +20,7 @@ const Navigationbar = (props) => {
                     <NavItem onClick={props.renderInfo}>About CopperCrown</NavItem>
                 </Nav>
                 <Nav pullRight>
-                    <NavDropdown title="Signed in as: No Name" id="basic-nav-dropdown">
+                    <NavDropdown title={titleName()} id="basic-nav-dropdown">
                         <MenuItem onClick={props.renderProfile}>Profile</MenuItem>
                         <MenuItem divider />
                         <MenuItem onClick={() => props.firebase.logout()}>Logout</MenuItem>
@@ -30,4 +31,26 @@ const Navigationbar = (props) => {
     )
 };
 
-export default firebaseConnect()(Navigationbar);
+function titleName(){
+    var string = this.props.auth.displayName; 
+return "Signed in as: "+string; 
+};
+
+//export default firebaseConnect()(Navigationbar);
+//Max://
+const mapStateToProps = ({firebase}, {auth}) => ({
+    userInfo: auth ? dataToJS(firebase, `users/${auth.uid}`) : undefined
+})
+
+const propsConnected = connect(mapStateToProps)(Navigationbar)
+
+const wrappedPlayerInfo = firebaseConnect(
+    ({auth}) => ([auth ? `users/${auth.uid}`: '/']))(propsConnected);
+
+const authConnected = connect(
+ ({ firebase }) => ({
+    auth: pathToJS(firebase, 'auth') // gets auth from redux and sets as prop
+  })
+)(wrappedPlayerInfo)
+
+export default authConnected

--- a/src/Components/Navigation/Navigationbar.jsx
+++ b/src/Components/Navigation/Navigationbar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+//import { firebaseConnect} from 'react-redux-firebase';
 import { connect } from 'react-redux';
 import { firebaseConnect, pathToJS, dataToJS} from 'react-redux-firebase';
 import {Navbar, Nav, NavItem, NavDropdown, MenuItem} from 'react-bootstrap';
@@ -20,7 +21,7 @@ const Navigationbar = (props) => {
                     <NavItem onClick={props.renderInfo}>About CopperCrown</NavItem>
                 </Nav>
                 <Nav pullRight>
-                    <NavDropdown title={titleName()} id="basic-nav-dropdown">
+                    <NavDropdown title={"Signed in as: "+props.auth.displayName} id="basic-nav-dropdown">
                         <MenuItem onClick={props.renderProfile}>Profile</MenuItem>
                         <MenuItem divider />
                         <MenuItem onClick={() => props.firebase.logout()}>Logout</MenuItem>
@@ -31,13 +32,6 @@ const Navigationbar = (props) => {
     )
 };
 
-function titleName(){
-    var string = this.props.auth.displayName; 
-return "Signed in as: "+string; 
-};
-
-//export default firebaseConnect()(Navigationbar);
-//Max://
 const mapStateToProps = ({firebase}, {auth}) => ({
     userInfo: auth ? dataToJS(firebase, `users/${auth.uid}`) : undefined
 })
@@ -53,4 +47,4 @@ const authConnected = connect(
   })
 )(wrappedPlayerInfo)
 
-export default authConnected
+export default authConnected;


### PR DESCRIPTION
Created string conjunction with call to get auth.displayName through provider to show as "Signed in: as: [displayName]" in Navbar. 